### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *py[co]
 RELEASE-VERSION
+/build/

--- a/nilsimsa/test.py
+++ b/nilsimsa/test.py
@@ -8,8 +8,15 @@ This software is released under an MIT/X11 open source license.
 Copyright 2012-2015 Diffeo, Inc.
 """
 from __future__ import absolute_import, division
-import cPickle as pickle
-import dircache
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+try:
+    from dircache import listdir
+except ImportError:
+    from os import listdir   # dircache gone in Python 3
 import os
 import pytest
 import random
@@ -29,7 +36,7 @@ def test_nilsimsa():
     computes the nilsimsa digest and compares to the true
     value stored in the pickled sid_to_nil dictionary
     """
-    fname = random.choice(dircache.listdir(test_data_dir))
+    fname = random.choice(listdir(test_data_dir))
     f = open(os.path.join(test_data_dir, fname), "rb")
     nil = Nilsimsa(f.read())
     f.close()
@@ -40,7 +47,7 @@ def test_nilsimsa_speed():
     computes nilsimsa hash for all test files and prints speed
     """
     corpus = []
-    for fname in dircache.listdir(test_data_dir):
+    for fname in listdir(test_data_dir):
         f = open(os.path.join(test_data_dir, fname), "rb")
         corpus.append(f.read())
         f.close()
@@ -48,8 +55,8 @@ def test_nilsimsa_speed():
     for text in corpus:
         Nilsimsa(text)
     elapsed = time.time() - start
-    print "%d in %f --> %f per second" % (
-        len(corpus), elapsed, len(corpus)/elapsed)
+    print("%d in %f --> %f per second" % (
+        len(corpus), elapsed, len(corpus)/elapsed))
 
 def test_unicode():
     """
@@ -98,7 +105,7 @@ def test_compatability():
     scores of 5 randomly selected documents from the test corpus
     and asserting that both give the same hexdigest
     """
-    names = dircache.listdir(test_data_dir)
+    names = listdir(test_data_dir)
     fnames = set([random.choice(names) for i in range(5)])
     for fname in fnames:
         f = open(os.path.join(test_data_dir, fname), "rb")

--- a/version.py
+++ b/version.py
@@ -31,7 +31,7 @@
 #
 #   include RELEASE-VERSION
  
-__all__ = ("get_git_version")
+__all__ = ["get_git_version"]
 
 import os
 import sys
@@ -50,13 +50,13 @@ def call_git_describe(abbrev=4):
     p = None
     try:
         p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
-                  stdout=PIPE, stderr=PIPE, 
+                  stdout=PIPE, stderr=PIPE, universal_newlines=True,
                   cwd=os.path.dirname(os.path.abspath(__file__)))
         p.stderr.close()
         describe_line = p.stdout.readlines()[0].strip()
 
         p = Popen(['git', 'rev-parse', 'HEAD'],
-                  stdout=PIPE, stderr=PIPE)
+                  stdout=PIPE, stderr=PIPE, universal_newlines=True)
         p.stderr.close()
         source_hash = p.stdout.readlines()[0].strip()
         source_hash = source_hash[:abbrev]
@@ -75,16 +75,16 @@ def call_git_describe(abbrev=4):
 
         return version, source_hash
  
-    except Exception, exc:
+    except Exception as exc:
         sys.stderr.write('line: %r\n' % line)
         sys.stderr.write(traceback.format_exc(exc))
         try:
             sys.stderr.write('p.stderr.read()=%s\n' % p.stderr.read())
-        except Exception, exc:
+        except Exception as exc:
             sys.stderr.write(traceback.format_exc(exc))
         try:
             sys.stderr.write('os.getcwd()=%s\n' % os.getcwd())
-        except Exception, exc:
+        except Exception as exc:
             sys.stderr.write(traceback.format_exc(exc))
         return None, None
  
@@ -145,4 +145,4 @@ def get_git_version(abbrev=4):
  
  
 if __name__ == "__main__":
-    print get_git_version()
+    print(get_git_version())


### PR DESCRIPTION
This package is now a dependency of [readthedocs-sphinx-ext](https://pypi.python.org/pypi/readthedocs-sphinx-ext), which was causing some of my readthedocs builds to fail on trying to install this.

These changes make the tests pass on Python 3 and enable installation on Python 3. They should not break anything on Python 2. I think they might also improve performance slightly, but the test runs vary so much (probably because of `random.choice()`) that I can't really tell.
